### PR TITLE
Refine slot machine messaging composition

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,19 +118,26 @@
       await animateReels(result);
 
       const payout = evaluate(result);
+      const messages = [];
+      let messageType = "info";
+
       if (payout > 0) {
         const win = payout * BET;
         credits += win;
         updateCredits();
-        msg(`You won $${win} (${payout}×)!`, "win");
+        messages.push(`You won $${win} (${payout}×)!`);
+        messageType = "win";
       } else {
-        msg("No win. Try again!");
+        messages.push("No win. Try again!");
       }
-      if (credits < BET) {
-        msg("You’re out of credits. Hit +$20 to keep playing.");
-      } else {
-        spinBtn.disabled = false;
+
+      const broke = credits < BET;
+      spinBtn.disabled = broke;
+      if (broke) {
+        messages.push("You’re out of credits. Hit +$20 to keep playing.");
       }
+
+      msg(messages.join(" "), messageType);
     });
 
     function updateCredits() {


### PR DESCRIPTION
## Summary
- gather result text in an array so the out-of-credits hint augments, rather than replaces, the win/loss message
- keep the spin button state tied to the broke flag without disturbing win styling

## Testing
- node - <<'NODE'
const PAY_TRIPLE = { "💎": 20, "🔔": 10, "🍀": 6, "🍒": 4, "🍋": 4, "🍇": 4 };
const BET = 1;
function evaluate([a, b, c]) {
  if (a === b && b === c) return PAY_TRIPLE[a] ?? 4;
  if (a === b || a === c || b === c) return 2;
  return 0;
}
console.assert(evaluate(["🍒","🍒","🍒"]) === 4);
console.assert(evaluate(["💎","💎","💎"]) === 20);
console.assert(evaluate(["🍒","🍒","🍋"]) === 2);
console.assert(evaluate(["🍒","🍋","🍒"]) === 2);
console.assert(evaluate(["🍒","🍋","🍇"]) === 0);
console.log("evaluate() logic OK");
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d3311346608324b914d94b7626a0e3